### PR TITLE
Improve betting flow and button toggling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,59 +1,113 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blackjack Game</title>
     <link rel="stylesheet" href="./src/css/style.css" />
     <link rel="shortcut icon" href="#" />
-    <meta />
   </head>
   <body>
     <div class="game">
-      <div class="game__header">
-        <h1>Blackjack</h1>
-      </div>
-      <div class="game__box">
-        <div class="game__box-table">
-          <div class="game__box-table-cards">
-            <div class="game__box-cards-dealer" id="game__box-dealer"></div>
-            <div class="game__box-points-dealer">
-              Dealer: <span id="dealer-result">0</span>
+      <div class="game__effects-layer" id="effects-layer"></div>
+      <header class="game__header">
+        <div class="game__title-block">
+          <h1 class="game__title">Blackjack Royale</h1>
+          <p class="game__subtitle">
+            Place your chips and take your shot against the house.
+          </p>
+        </div>
+        <div class="game__status">
+          <div class="status-card status-card--balance">
+            <span class="status-card__label">Balance</span>
+            <span class="status-card__value" id="game-money">$1,000</span>
+            <div class="chip-stack chip-stack--bank" id="balance-chip-stack"></div>
+            <div class="chip-anchor" id="bank-anchor"></div>
+          </div>
+          <div class="status-card">
+            <span class="status-card__label">Win streak</span>
+            <span class="status-card__value" id="game-streak">0</span>
+          </div>
+        </div>
+      </header>
+      <main class="game__table">
+        <div class="table">
+          <div class="table__felt">
+            <div class="table__side table__side--dealer">
+              <div class="table__label">
+                <span class="table__label-text">Dealer</span>
+                <span class="score-pill" id="dealer-result">0</span>
+              </div>
+              <div class="table__card-row" id="game__box-dealer"></div>
+              <div class="chip-anchor chip-anchor--dealer" id="dealer-anchor"></div>
             </div>
-            <div class="game__box-cards-player" id="game__box-player"></div>
-            <div class="game__box-points-player">
-              You: <span id="player-result">0</span>
+            <div class="table__pot">
+              <div class="table__pot-inner" id="pot-anchor">
+                <span class="table__pot-label">Pot</span>
+                <span class="table__pot-amount" id="bet-pot-amount">$0</span>
+                <div class="chip-stack chip-stack--pot" id="pot-chip-stack"></div>
+              </div>
+              <div class="table__announcement" id="status-banner">
+                Place your bet to begin
+              </div>
+            </div>
+            <div class="table__side table__side--player">
+              <div class="table__label">
+                <span class="table__label-text">Player</span>
+                <span class="score-pill" id="player-result">0</span>
+              </div>
+              <div
+                class="table__card-row table__card-row--player"
+                id="game__box-player"
+              ></div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="game__buttons">
-        <input
-          class="game__buttons-input"
-          type="number"
-          id="bet-input"
-          value="100"
-        />
-        <button class="game__buttons-button" id="bet-button">Bet</button>
-        <button class="game__buttons-button" id="deal-button">Deal</button>
-        <button class="game__buttons-button" id="stand-button">Stand</button>
-        <button class="game__buttons-button" id="hit-button">Hit</button>
-      </div>
-      <div class="game__stats">
-        <h3>Balance: <b>$</b><span id="game-money">1000</span></h3>
-        <h3>Win streak: <span id="game-streak">0</span></h3>
-        <h3><a href="#">History</a></h3>
-        <h3><a href="./rules.html">Rules</a></h3>
-        <h3><a href="#">Login</a></h3>
-      </div>
+      </main>
+      <section class="game__controls">
+        <div class="controls__betting">
+          <div class="controls__input">
+            <label class="controls__label" for="bet-input">Bet amount</label>
+            <div class="controls__input-group">
+              <input
+                class="controls__input-field"
+                type="number"
+                id="bet-input"
+                min="0"
+                step="10"
+                value="100"
+              />
+              <button class="button button--primary" id="bet-button">Lock bet</button>
+            </div>
+          </div>
+          <div class="controls__quick">
+            <span class="controls__label">Quick chips</span>
+            <div class="controls__quick-grid">
+              <button class="chip-button" data-quick-bet="10">$10</button>
+              <button class="chip-button" data-quick-bet="25">$25</button>
+              <button class="chip-button" data-quick-bet="50">$50</button>
+              <button class="chip-button" data-quick-bet="100">$100</button>
+              <button class="chip-button" data-quick-bet="250">$250</button>
+            </div>
+          </div>
+          <div class="controls__actions">
+            <button class="button button--ghost" id="clear-bet-button">Clear</button>
+            <button class="button button--ghost" id="double-bet-button">Double</button>
+            <button class="button button--accent" id="max-bet-button">All in</button>
+          </div>
+        </div>
+        <div class="controls__play">
+          <button class="button button--deal" id="deal-button">Deal</button>
+          <button class="button button--action" id="stand-button">Stand</button>
+          <button class="button button--action" id="hit-button">Hit</button>
+        </div>
+        <div class="game__links">
+          <a href="#">History</a>
+          <a href="./rules.html">Rules</a>
+          <a href="#">Login</a>
+        </div>
+      </section>
     </div>
     <script src="./src/js/script.js" type="module"></script>
   </body>
 </html>
-
-<!--Notas en Desarrollo
-
-> fix cards position in player box
-> fix game__box-points boxes 
-> animate showing cards
-
--->

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,153 +1,853 @@
+:root {
+  --bg-body: #021312;
+  --bg-body-accent: #0a2b28;
+  --felt: #0f6b3d;
+  --felt-light: #17824d;
+  --felt-dark: #05331d;
+  --rail: #4a2300;
+  --text-primary: #f1f8f5;
+  --text-muted: rgba(241, 248, 245, 0.65);
+  --accent: #ffd54f;
+  --accent-strong: #ffb300;
+  --accent-soft: #ffe082;
+  --danger: #ff5252;
+  --success: #66ffa6;
+  --draw: #ffd740;
+  --control-bg: rgba(7, 37, 28, 0.85);
+  --control-border: rgba(255, 255, 255, 0.08);
+  --button-radius: 999px;
+  --transition: 0.3s ease;
+}
+
 * {
   box-sizing: border-box;
-  font-family: Arial, Helvetica, sans-serif;
-  margin: 0;
-  padding: 0;
 }
 
 body {
-}
-
-.game__header {
-  text-align: center;
+  margin: 0;
+  min-height: 100vh;
+  padding: clamp(1rem, 2vw, 2.5rem);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at 20% 20%, #093d35, var(--bg-body) 65%);
+  color: var(--text-primary);
+  font-family: "Poppins", "Segoe UI", Roboto, sans-serif;
 }
 
 .game {
-  height: 100vh;
-  width: 100vw;
-  background-color: #acc;
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
+  width: min(1100px, 100%);
+  background: linear-gradient(160deg, rgba(4, 30, 27, 0.95), rgba(7, 45, 32, 0.9));
+  border-radius: 32px;
   overflow: hidden;
+  box-shadow: 0 40px 90px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px);
 }
 
-.game__box {
-  margin: auto;
-  font-size: 2em;
-  height: 70%;
-  text-align: center;
-  background-color: #093;
+.game__effects-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 30;
 }
 
-/*Header section*/
 .game__header {
   position: relative;
   z-index: 10;
-  background-color: yellow;
-}
-
-/*Table section*/
-.game__box-table {
-  position: absolute;
-  margin: auto;
-  left: 50%;
-  top: 0;
-  transform: translate(-50%, -50%);
-  z-index: 2;
-  height: 1400px;
-  width: 1500px;
-  border-radius: 0 0 1450px 1450px;
-  border: 20px solid #873600;
-  background: rgb(0, 142, 58);
-  background: radial-gradient(
-    circle,
-    rgba(0, 142, 58, 1) 0%,
-    rgba(0, 54, 22, 1) 100%
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(1rem, 2vw, 2.5rem);
+  padding: clamp(1.5rem, 2vw, 2.75rem);
+  background: linear-gradient(
+    120deg,
+    rgba(11, 54, 40, 0.92),
+    rgba(3, 24, 20, 0.88)
   );
-  margin: auto;
 }
 
-/*Card style and animation*/
+.game__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 
-/* Cards section*/
-.game__box-table-cards {
-  margin: auto;
-  width: 1500px;
-  height: 633px;
-  background: transparent;
-  position: absolute;
-  z-index: 50;
-  top: 722px;
+.game__subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+  max-width: 28ch;
+}
+
+.game__status {
+  display: flex;
+  gap: clamp(1rem, 1.6vw, 1.75rem);
+  align-items: stretch;
+}
+
+.status-card {
+  position: relative;
+  padding: 1rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(4, 40, 30, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  min-width: 160px;
   display: flex;
   flex-direction: column;
+  gap: 0.4rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.game__box-cards-dealer {
-  height: 50%;
-  text-align: center;
-  display: flex;
-  flex-direction: row;
+.status-card__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.status-card__value {
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+}
+
+.status-card--balance {
+  padding-right: 2.75rem;
+}
+
+.status-card--balance .chip-stack {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+}
+
+.status-card--balance #bank-anchor {
+  position: absolute;
+  right: 0.5rem;
+  top: 55%;
+  transform: translateY(-50%);
+}
+
+.game__table {
+  padding: clamp(1.5rem, 3vw, 3rem);
+}
+
+.table {
+  position: relative;
+  width: 100%;
+  border-radius: 40px 40px 80px 80px;
+  background: radial-gradient(
+    circle at 50% 20%,
+    rgba(24, 111, 64, 0.95),
+    rgba(4, 52, 31, 0.95)
+  );
+  border: 14px solid var(--rail);
+  box-shadow: inset 0 0 35px rgba(0, 0, 0, 0.5),
+    0 35px 60px rgba(0, 0, 0, 0.5);
+}
+
+.table::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 26px 26px 70px 70px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.table__felt {
+  position: relative;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem)
+    clamp(2.5rem, 5vw, 4.5rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.75rem, 4vw, 3rem);
+}
+
+.table__side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  width: 100%;
+  position: relative;
+}
+
+.table__label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.table__label-text {
+  font-weight: 600;
+}
+
+.table__card-row {
+  position: relative;
+  width: min(90%, 620px);
+  min-height: clamp(160px, 22vh, 220px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  padding: 0.5rem 0;
+}
+
+.table__card-row img {
+  user-select: none;
+  pointer-events: none;
+}
+
+.score-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: rgba(0, 0, 0, 0.4);
+  color: var(--text-primary);
+  min-width: 3.5rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.score-pill--win {
+  background: rgba(76, 175, 80, 0.25);
+  color: #98ffb5;
+}
+
+.score-pill--lose {
+  background: rgba(244, 67, 54, 0.25);
+  color: #ff8a80;
+}
+
+.score-pill--draw {
+  background: rgba(255, 214, 64, 0.25);
+  color: #ffecb3;
+}
+
+.score-pill--bust {
+  background: rgba(244, 67, 54, 0.35);
+  color: #ffdede;
+}
+
+.table__pot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.table__pot-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: clamp(150px, 22vw, 220px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 50% 40%,
+    rgba(255, 224, 130, 0.18),
+    rgba(0, 0, 0, 0)
+  );
+  border: 4px solid rgba(255, 215, 64, 0.35);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4);
+}
+
+.table__pot-inner.is-glowing {
+  animation: potGlow 0.9s ease-out;
+}
+
+@keyframes potGlow {
+  0% {
+    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4),
+      0 0 0 rgba(255, 214, 64, 0);
+  }
+  45% {
+    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4),
+      0 0 35px rgba(255, 214, 64, 0.7);
+  }
+  100% {
+    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4),
+      0 0 0 rgba(255, 214, 64, 0);
+  }
+}
+
+.table__pot-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.table__pot-amount {
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+  font-weight: 600;
+  margin-top: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.table__announcement {
+  font-size: clamp(1rem, 1.8vw, 1.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.45rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+  text-align: center;
+}
+
+.table__announcement--info {
+  color: #ffe082;
+  border-color: rgba(255, 224, 130, 0.45);
+}
+
+.table__announcement--win {
+  color: #8cffc1;
+  border-color: rgba(140, 255, 193, 0.55);
+}
+
+.table__announcement--lose {
+  color: #ff8a80;
+  border-color: rgba(255, 138, 128, 0.45);
+}
+
+.table__announcement--draw {
+  color: #ffd740;
+  border-color: rgba(255, 215, 64, 0.45);
+}
+
+.table__announcement--alert {
+  color: #ff8a80;
+  border-color: rgba(255, 138, 128, 0.6);
+}
+
+.card {
+  --tx: 0px;
+  --ty: 0px;
+  --rot: 0deg;
+  width: clamp(88px, 12vw, 150px);
+  border-radius: 16px;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45);
+  transform: translate(var(--tx), var(--ty)) rotate(var(--rot));
+  animation: cardEnter 0.5s ease forwards;
+  opacity: 0;
+  backface-visibility: hidden;
+}
+
+.card--player {
+  --ty: 40px;
+}
+
+.card--dealer {
+  --ty: -20px;
+}
+
+@keyframes cardEnter {
+  0% {
+    transform: translate(var(--tx), calc(var(--ty) - 70px))
+      rotate(calc(var(--rot) - 12deg));
+    opacity: 0;
+  }
+  100% {
+    transform: translate(var(--tx), var(--ty)) rotate(var(--rot));
+    opacity: 1;
+  }
+}
+
+.chip-anchor {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  pointer-events: none;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.chip-anchor::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 221, 128, 0.45),
+    rgba(255, 221, 128, 0)
+  );
+  opacity: 0;
+}
+
+.chip-anchor.is-glowing::after {
+  animation: anchorPulse 0.9s ease-out;
+}
+
+@keyframes anchorPulse {
+  0% {
+    transform: scale(0.4);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1.4);
+    opacity: 0;
+  }
+}
+
+.chip-anchor--dealer {
+  top: auto;
+  bottom: -12px;
+}
+
+.game__controls {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2.5vw, 2rem);
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  background: linear-gradient(
+    180deg,
+    rgba(5, 31, 26, 0.94),
+    rgba(3, 18, 15, 0.9)
+  );
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.controls__betting {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+@media (min-width: 768px) {
+  .controls__betting {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: flex-end;
+  }
+}
+
+.controls__input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.controls__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.controls__input-group {
+  display: flex;
+  gap: 0.65rem;
   align-items: center;
 }
 
-.game__box-cards-player {
-  text-align: center;
-  height: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-/*Buttons section*/
-.game__buttons {
-  text-align: center;
-  height: 15%;
-  background-color: #093;
-}
-.game__buttons-input {
-  font-size: 1.5em;
-  border-radius: 5px;
-  margin-top: 20px;
-  width: 100px;
-}
-.game__buttons-button {
-  display: inline-block;
-  height: 40px;
-  width: 70px;
-  background-color: red;
-  text-align: center;
-  border: 1px solid black;
-  border-radius: 3px;
-  margin: 10px;
-  font-size: 15px;
-}
-#bet-button {
-  background-color: yellow;
-}
-#stand-button {
-  background-color: red;
-}
-#hit-button {
-  background-color: #f93;
-}
-#deal-button {
-  background-color: aqua;
-}
-/*Stats section*/
-.game__stats {
-  color: #fff;
-  height: 15%;
-  background-color: #222;
-  text-align: center;
+.controls__input-field {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--control-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border var(--transition), box-shadow var(--transition),
+    transform 0.3s ease;
+  -moz-appearance: textfield;
 }
 
-.game__stats h3 {
-  display: inline-block;
-  margin-left: 50px;
-  margin-top: 30px;
-  font-size: 25px;
+.controls__input-field::-webkit-outer-spin-button,
+.controls__input-field::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
 }
-.game__stats > h3 > a {
+
+.controls__input-field:focus {
+  outline: none;
+  border-color: rgba(255, 224, 130, 0.8);
+  box-shadow: 0 0 0 3px rgba(255, 224, 130, 0.2);
+}
+
+.controls__input-field.has-error {
+  border-color: rgba(255, 138, 128, 0.8);
+  animation: wiggle 0.35s ease;
+}
+
+@keyframes wiggle {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  50% {
+    transform: translateX(6px);
+  }
+  75% {
+    transform: translateX(-3px);
+  }
+}
+
+.controls__quick {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.controls__quick-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.chip-button {
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.65rem 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: radial-gradient(
+    circle at 30% 30%,
+    #ffe082,
+    #ffb300 60%,
+    #ef6c00
+  );
+  color: #3e1c00;
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chip-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.35);
+}
+
+.chip-button:active {
+  transform: translateY(0);
+}
+
+.controls__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.controls__play {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.button {
+  border: none;
+  cursor: pointer;
+  border-radius: var(--button-radius);
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  color: #01261f;
+  background: var(--accent-soft);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.25);
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #ffe082, #ffb300);
+  color: #4a2c00;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.button--accent {
+  background: linear-gradient(135deg, #ffab40, #ff6f00);
+  color: #3c1d00;
+}
+
+.button--deal {
+  background: linear-gradient(135deg, #00e676, #00b248);
+  color: #003319;
+}
+
+.button--action {
+  background: linear-gradient(135deg, #4fc3f7, #0288d1);
+  color: #001b2e;
+}
+
+.game__links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.game__links a {
+  color: var(--text-muted);
   text-decoration: none;
-  color: #fff;
-  border: 2px solid #fff;
-  border-radius: 5px;
-  padding: 5px;
-  transition: 0.3s;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
 }
 
-.game__stats > h3 > a:hover {
-  color: #000;
-  background-color: #fff;
+.game__links a:hover {
+  color: var(--accent-soft);
+  text-shadow: 0 0 8px rgba(255, 224, 130, 0.5);
+}
+
+.chip-stack {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  pointer-events: none;
+}
+
+.chip-stack--bank {
+  --chip-light: #c8e6c9;
+  --chip-mid: #81c784;
+  --chip-dark: #2e7d32;
+}
+
+.chip-stack--pot {
+  --chip-light: #ffecb3;
+  --chip-mid: #fbc02d;
+  --chip-dark: #f57f17;
+}
+
+.chip-stack__chip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--chip-index) * 6px);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  transform: translate(-50%, 0);
+  background: radial-gradient(
+    circle at 30% 30%,
+    var(--chip-light),
+    var(--chip-mid) 60%,
+    var(--chip-dark)
+  );
+  border: 4px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 7px 15px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  animation: chipStackIn 0.45s ease forwards;
+  animation-delay: calc(var(--chip-index) * 0.04s);
+}
+
+.chip-stack__chip::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 50%;
+}
+
+@keyframes chipStackIn {
+  0% {
+    transform: translate(-50%, 12px);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+}
+
+.flying-chip {
+  position: absolute;
+  width: clamp(64px, 8vw, 82px);
+  height: clamp(64px, 8vw, 82px);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 30% 30%,
+    var(--chip-light, #ffe082),
+    var(--chip-mid, #ffb300) 60%,
+    var(--chip-dark, #ef6c00)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #3e1c00;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(0.6);
+  opacity: 0;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  transition: left 0.6s ease, top 0.6s ease, opacity 0.6s ease,
+    transform 0.6s ease;
+  z-index: 120;
+}
+
+.flying-chip::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  border: 2px dashed rgba(0, 0, 0, 0.18);
+  opacity: 0.7;
+}
+
+.flying-chip--bet {
+  --chip-light: #ffe082;
+  --chip-mid: #ffb300;
+  --chip-dark: #ef6c00;
+}
+
+.flying-chip--return {
+  --chip-light: #bbdefb;
+  --chip-mid: #64b5f6;
+  --chip-dark: #1976d2;
+  color: #082542;
+}
+
+.flying-chip--win {
+  --chip-light: #c8e6c9;
+  --chip-mid: #81c784;
+  --chip-dark: #388e3c;
+  color: #0b3d1f;
+}
+
+.flying-chip--dealer {
+  --chip-light: #ffcdd2;
+  --chip-mid: #ef9a9a;
+  --chip-dark: #c62828;
+  color: #4a1512;
+}
+
+.is-pulsing {
+  animation: elementPulse 0.6s ease;
+}
+
+@keyframes elementPulse {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.game__links .is-pulsing {
+  transform-origin: center;
+}
+
+@media (max-width: 900px) {
+  .game__status {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .status-card {
+    flex: 1;
+  }
+
+  .status-card--balance {
+    padding-right: 2.25rem;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .game__header {
+    flex-direction: column;
+  }
+
+  .status-card {
+    min-width: auto;
+  }
+
+  .game__controls {
+    padding: 1.5rem;
+  }
+
+  .controls__betting {
+    grid-template-columns: 1fr;
+  }
+
+  .table__card-row {
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .controls__input-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls__input-field {
+    width: 100%;
+  }
+
+  .button,
+  .chip-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .controls__actions,
+  .controls__play {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary
- validate bets before dealing, track the wager in play, and block dealing without a stake
- update balance handling to refund/credit correctly and re-enable betting at the end of each round
- harden button toggling by disabling hidden buttons to prevent accidental clicks

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d3d3dd1e5883328b2444aeabd86e47